### PR TITLE
Update view_component dependency in gemspec

### DIFF
--- a/ahoy_captain.gemspec
+++ b/ahoy_captain.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", ">= 6"
   spec.add_dependency "ransack", ">= 2.3"
   spec.add_dependency "turbo-rails", ">= 1.2"
-  spec.add_dependency "view_component", ">= 2"
+  spec.add_dependency "view_component", ">= 3"
   spec.add_dependency "importmap-rails", ">= 1"
   spec.add_dependency "stimulus-rails", ">= 1.1"
   spec.add_dependency "ahoy_matey", ">= 1.1"


### PR DESCRIPTION
I think this needs to be `>= 3` due to the use of the `with_SLOT_NAME_content` method, used at least once here:

https://github.com/joshmn/ahoy_captain/blob/0991f09670009f2039ca4099ec977bf8ba834010/app/components/ahoy_captain/dropdown_link_component.rb#L13

That method was added in version 3: https://viewcomponent.org/CHANGELOG.html#v300rc6