### PR TITLE
Funnel strategies

### DIFF
--- a/lib/ahoy_captain.rb
+++ b/lib/ahoy_captain.rb
@@ -7,6 +7,10 @@ require "ahoy_captain/configuration"
 require "ahoy_captain/predicate_label"
 require 'ahoy_captain/ahoy/visit_methods'
 require 'ahoy_captain/ahoy/event_methods'
+require "ahoy_captain/strategies/base"
+require "ahoy_captain/strategies/total_events"
+require "ahoy_captain/strategies/user_participation"
+require "ahoy_captain/strategy_factory"
 
 require 'importmap-rails'
 

--- a/lib/ahoy_captain/funnels.rb
+++ b/lib/ahoy_captain/funnels.rb
@@ -1,12 +1,16 @@
 module AhoyCaptain
   class Funnel
+    VALID_STRATEGIES = [:total, :participation].freeze
+
     attr_accessor :id
     attr_reader :goals
+    attr_reader :strategy
 
     def initialize
       @id = nil
       @label = nil
       @goals = []
+      @strategy = :total
     end
 
     def goal(id)
@@ -15,6 +19,13 @@ module AhoyCaptain
 
     def label(value)
       @label = value
+    end
+
+    def strategy(value = nil)
+      return @strategy unless value
+      
+      raise ArgumentError, "Invalid strategy: #{value}. Must be one of: #{VALID_STRATEGIES.join(', ')}" unless VALID_STRATEGIES.include?(value)
+      @strategy = value
     end
 
     def title

--- a/lib/ahoy_captain/strategies/base.rb
+++ b/lib/ahoy_captain/strategies/base.rb
@@ -1,0 +1,17 @@
+module AhoyCaptain
+  module Strategies
+    class Base
+      def initialize(event_query)
+        @event_query = event_query
+      end
+
+      def build_total_query(table_name)
+        raise NotImplementedError
+      end
+
+      def build_goal_query(table_name, goal_id, index)
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/lib/ahoy_captain/strategies/total_events.rb
+++ b/lib/ahoy_captain/strategies/total_events.rb
@@ -1,0 +1,23 @@
+module AhoyCaptain
+  module Strategies
+    class TotalEvents < Base
+      def build_total_query(table_name)
+        @event_query.select(
+          "count(distinct(#{table_name}.user_id)) as unique_visits, 
+           '_internal_total_visits_' as name, 
+           count(distinct #{table_name}.id) as total_events, 
+           0 as sort_order"
+        )
+      end
+
+      def build_goal_query(table_name, goal_id, index)
+        @event_query.select(
+          "count(distinct(#{table_name}.user_id)) as unique_visits, 
+           '#{goal_id}' as name, 
+           count(distinct #{table_name}.id) as total_events, 
+           #{index + 1} as sort_order"
+        )
+      end
+    end
+  end
+end

--- a/lib/ahoy_captain/strategies/user_participation.rb
+++ b/lib/ahoy_captain/strategies/user_participation.rb
@@ -1,0 +1,23 @@
+module AhoyCaptain
+  module Strategies
+    class UserParticipation < Base
+      def build_total_query(table_name)
+        @event_query.select(
+          "count(distinct(#{table_name}.user_id)) as unique_visits, 
+           '_internal_total_visits_' as name, 
+           count(distinct #{table_name}.user_id) as total_events, 
+           0 as sort_order"
+        )
+      end
+
+      def build_goal_query(table_name, goal_id, index)
+        @event_query.select(
+          "count(distinct(#{table_name}.user_id)) as unique_visits, 
+           '#{goal_id}' as name, 
+           count(distinct #{table_name}.user_id) as total_events, 
+           #{index + 1} as sort_order"
+        )
+      end
+    end
+  end
+end

--- a/lib/ahoy_captain/strategy_factory.rb
+++ b/lib/ahoy_captain/strategy_factory.rb
@@ -1,0 +1,13 @@
+module AhoyCaptain
+  class StrategyFactory
+    STRATEGIES = {
+      total: Strategies::TotalEvents,
+      participation: Strategies::UserParticipation
+    }.freeze
+
+    def self.build(strategy_name, event_query)
+      strategy_class = STRATEGIES[strategy_name] || STRATEGIES[:total]
+      strategy_class.new(event_query)
+    end
+  end
+end


### PR DESCRIPTION
Currently the funnel shows total events. This is not always useful when, for example, we calculate conversion between funnel steps. In that case we should have different strategy - we should check if user does an action.

Here is a code that improves funnels by adding option **strategy** , that is total (default) or uniq. It's possible to add more strategies without hassle too.

If PR accepted, updating of wiki is required. 